### PR TITLE
userLimit check for handleJoin(), error codes/messages

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -120,7 +120,6 @@ class Server {
 		void 		channelKeyMode(Client& client, Channel& channel, char operation, const std::string& key);
 		void		topicRestrictionMode(Client& client, Channel& channel, char operation);
 		void		operatorMode(Client& client, Channel& channel, char operation, const std::string& user);
-		void		userLimitMode(Client& client, Channel& channel, char operation, const std::string& user);
 		bool		isValidUserLimit(const std::string& str, int& userLimit);
   
 		void		handleTopic(Client& client, const std::vector<std::string>& params);

--- a/includes/responseCodes.hpp
+++ b/includes/responseCodes.hpp
@@ -36,6 +36,7 @@
 #define ERR_NEEDMOREPARAMS 		461 // Not enough parameters
 #define ERR_ALREADYREGISTERED	462 // Tries when already registered
 #define ERR_PASSWDMISMATCH		464 // incorrect password
+#define ERR_CHANNELISFULL		471 // channel is full (user limit reached)
 #define ERR_INVITEONLYCHAN		473 // trying to join an invite-only channel without invitation
 #define ERR_BADCHANNELKEY		475
 #define ERR_BADCHANMASK			479 // channel name does not match the proper syntax


### PR DESCRIPTION
adds:
- a check in handleJoin() to check whether a channel is full (easy to test with '/mode #channel +l 1' to set a single member user limit and then try to connect with another client)
- ERR_CHANNELISFULL macro
- sending the correct IRC error codes to client (ERR_CHANNELISFULL, ERR_INVITEONLYCHAN), the client seems to recognize these correctly now